### PR TITLE
Current release, plus local fix

### DIFF
--- a/lib/ios/AirMaps/AIRMapMarker.m
+++ b/lib/ios/AirMaps/AIRMapMarker.m
@@ -151,7 +151,7 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 {
     _calloutIsOpen = YES;
     [self setZIndex:_zIndexBeforeOpen];
-    
+
     MKAnnotationView *annotationView = [self getAnnotationView];
 
     [self setSelected:YES animated:NO];
@@ -203,12 +203,12 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 - (void)_handleTap:(UITapGestureRecognizer *)recognizer {
     AIRMapMarker *marker = self;
     if (!marker) return;
-    
+
     if (marker.selected) {
         CGPoint touchPoint = [recognizer locationInView:marker.map.calloutView];
         CGRect bubbleFrame = [self.calloutView convertRect:marker.map.calloutView.bounds toView:marker.map];
         CGPoint touchPointReal = [recognizer locationInView:self.calloutView];
-        
+
         UIView *calloutView = [marker.map.calloutView hitTest:touchPoint withEvent:nil];
         if (calloutView) {
             // the callout (or its subview) got clicked, not the marker
@@ -222,7 +222,7 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
                 }
                 tmp = tmp.superview;
             }
-            
+
             id event = @{
                          @"action": calloutSubview ? @"callout-inside-press" : @"callout-press",
                          @"id": marker.identifier ?: @"unknown",
@@ -237,7 +237,7 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
                              @"height": @(bubbleFrame.size.height),
                              }
                          };
-            
+
             if (calloutSubview) calloutSubview.onPress(event);
             if (marker.onCalloutPress) marker.onCalloutPress(event);
             if (marker.calloutView && marker.calloutView.onPress) marker.calloutView.onPress(event);
@@ -245,7 +245,7 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
             return;
         }
     }
-    
+
     // the actual marker got clicked
     id event = @{
                  @"action": @"marker-press",
@@ -255,11 +255,9 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
                          @"longitude": @(marker.coordinate.longitude)
                          }
                  };
-    
+
     if (marker.onPress) marker.onPress(event);
     if (marker.map.onMarkerPress) marker.map.onMarkerPress(event);
-    
-    [marker.map selectAnnotation:marker animated:NO];
 }
 
 - (void)hideCalloutView


### PR DESCRIPTION
This is not actually a PR, but is just to track the change made here. This contains the current most recent release of react native maps, and cherry picks our fix for selecting a single pin. This is because currently master of react native maps is broken.

https://github.com/react-native-community/react-native-maps/releases